### PR TITLE
Fixes SSL failure to connect using proxy or .war

### DIFF
--- a/agent/jsr160/src/main/java/org/jolokia/jsr160/Jsr160RequestDispatcher.java
+++ b/agent/jsr160/src/main/java/org/jolokia/jsr160/Jsr160RequestDispatcher.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 import javax.management.*;
 import javax.management.remote.*;
 import javax.naming.Context;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
 
 import org.jolokia.backend.RequestDispatcher;
 import org.jolokia.backend.executor.MBeanServerExecutor;
@@ -153,6 +154,10 @@ public class Jsr160RequestDispatcher implements RequestDispatcher {
             ret.put(Context.SECURITY_PRINCIPAL, user);
             ret.put(Context.SECURITY_CREDENTIALS, password);
             ret.put("jmx.remote.credentials",new String[] { user, password });
+        }
+        // Prevents error "java.rmi.ConnectIOException: non-JRMP server at remote endpoint"
+        if (!System.getProperty("javax.net.ssl.trustStore", "NULL").equals("NULL")) {
+            ret.put("com.sun.jndi.rmi.factory.socket", new SslRMIClientSocketFactory());
         }
         return ret;
     }


### PR DESCRIPTION
Adds SSL-RMI support when the `javax.net.ssl.trustStore` system property is defined and fixes error "java.rmi.ConnectIOException: non-JRMP server at remote endpoint"